### PR TITLE
feat(core): Implement Geometry and Identifier Utilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,6 +144,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -315,6 +321,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+ "serde",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cbb1126afed61dd6368748dae63b1ee7dc480191c6262a3b4ff1e29d86a6c5b"
+dependencies = [
+ "fastrand",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d713258393a82f091ead52047ca779d37e5766226d009de21696c4e667044368"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -445,8 +494,29 @@ version = "0.1.0-alpha.1"
 dependencies = [
  "bitflags",
  "nalgebra",
+ "phf",
  "slotmap",
  "thiserror",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -461,6 +531,12 @@ dependencies = [
  "paste",
  "wide",
 ]
+
+[[package]]
+name = "siphasher"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "slotmap"

--- a/crates/scream-core/Cargo.toml
+++ b/crates/scream-core/Cargo.toml
@@ -10,5 +10,6 @@ edition.workspace = true
 [dependencies]
 bitflags = "2.9.1"
 nalgebra = "0.33.2"
+phf = { version = "0.12.1", features = ["macros"] }
 slotmap = "1.0.7"
 thiserror = "2.0.12"

--- a/crates/scream-core/src/core/io/bgf.rs
+++ b/crates/scream-core/src/core/io/bgf.rs
@@ -2,6 +2,7 @@ use super::traits::MolecularFile;
 use crate::core::models::atom::Atom;
 use crate::core::models::chain::ChainType;
 use crate::core::models::ids::{ChainId, ResidueId};
+use crate::core::models::residue::ResidueType;
 use crate::core::models::system::MolecularSystem;
 use crate::core::models::topology::BondOrder;
 use nalgebra::Point3;
@@ -115,8 +116,12 @@ impl MolecularFile for BgfFile {
             }
 
             if new_residue {
-                current_residue_id =
-                    system.add_residue(active_chain_id, res_seq, &atom_info.res_name);
+                current_residue_id = system.add_residue(
+                    active_chain_id,
+                    res_seq,
+                    &atom_info.res_name,
+                    ResidueType::from_str_optional(&atom_info.res_name),
+                );
             }
             let active_residue_id = current_residue_id
                 .ok_or_else(|| BgfError::Logic("Failed to create or find residue".to_string()))?;
@@ -371,7 +376,9 @@ mod tests {
     fn create_test_system() -> MolecularSystem {
         let mut system = MolecularSystem::new();
         let chain_a = system.add_chain('A', ChainType::Protein);
-        let res1 = system.add_residue(chain_a, 1, "GLY").unwrap();
+        let res1 = system
+            .add_residue(chain_a, 1, "GLY", ResidueType::from_str_optional("GLY"))
+            .unwrap();
         let mut atom_n = Atom::new(1, "N", res1, Point3::new(-0.416, -0.535, 0.0));
         atom_n.partial_charge = -0.35;
         atom_n.force_field_type = "N_3".to_string();
@@ -561,7 +568,7 @@ END
         let chain_id = ChainId::default();
         let res_id = ResidueId::default();
         let atom = Atom::new(1, "CA", res_id, Point3::new(1.1, 2.2, 3.3));
-        let residue = Residue::new(5, "ALA", chain_id);
+        let residue = Residue::new(5, "ALA", Some(ResidueType::Alanine), chain_id);
         let chain = Chain::new('A', ChainType::Protein);
 
         let mut atom_to_format = atom;

--- a/crates/scream-core/src/core/mod.rs
+++ b/crates/scream-core/src/core/mod.rs
@@ -1,2 +1,3 @@
 pub mod io;
 pub mod models;
+pub mod utils;

--- a/crates/scream-core/src/core/models/residue.rs
+++ b/crates/scream-core/src/core/models/residue.rs
@@ -76,6 +76,34 @@ impl FromStr for ResidueType {
 }
 
 impl ResidueType {
+    pub fn from_str_optional(s: &str) -> Option<Self> {
+        match s.trim().to_uppercase().as_str() {
+            "ALA" => Some(ResidueType::Alanine),
+            "GLY" => Some(ResidueType::Glycine),
+            "ILE" => Some(ResidueType::Isoleucine),
+            "LEU" => Some(ResidueType::Leucine),
+            "PRO" => Some(ResidueType::Proline),
+            "VAL" => Some(ResidueType::Valine),
+            "PHE" => Some(ResidueType::Phenylalanine),
+            "TRP" => Some(ResidueType::Tryptophan),
+            "TYR" => Some(ResidueType::Tyrosine),
+            "ASN" => Some(ResidueType::Asparagine),
+            "CYS" => Some(ResidueType::Cysteine),
+            "GLN" => Some(ResidueType::Glutamine),
+            "SER" => Some(ResidueType::Serine),
+            "THR" => Some(ResidueType::Threonine),
+            "MET" => Some(ResidueType::Methionine),
+            "ARG" => Some(ResidueType::Arginine),
+            "LYS" => Some(ResidueType::Lysine),
+            "ASP" => Some(ResidueType::AsparticAcid),
+            "GLU" => Some(ResidueType::GlutamicAcid),
+            "HIS" => Some(ResidueType::Histidine),
+            "HSE" => Some(ResidueType::HistidineEpsilon),
+            "HSP" => Some(ResidueType::HistidineProtonated),
+            _ => None,
+        }
+    }
+
     pub fn to_three_letter(self) -> &'static str {
         match self {
             ResidueType::Alanine => "ALA",

--- a/crates/scream-core/src/core/models/residue.rs
+++ b/crates/scream-core/src/core/models/residue.rs
@@ -47,36 +47,13 @@ pub struct ParseResidueTypeError(pub String);
 impl FromStr for ResidueType {
     type Err = ParseResidueTypeError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.trim().to_uppercase().as_str() {
-            "ALA" => Ok(ResidueType::Alanine),
-            "GLY" => Ok(ResidueType::Glycine),
-            "ILE" => Ok(ResidueType::Isoleucine),
-            "LEU" => Ok(ResidueType::Leucine),
-            "PRO" => Ok(ResidueType::Proline),
-            "VAL" => Ok(ResidueType::Valine),
-            "PHE" => Ok(ResidueType::Phenylalanine),
-            "TRP" => Ok(ResidueType::Tryptophan),
-            "TYR" => Ok(ResidueType::Tyrosine),
-            "ASN" => Ok(ResidueType::Asparagine),
-            "CYS" => Ok(ResidueType::Cysteine),
-            "GLN" => Ok(ResidueType::Glutamine),
-            "SER" => Ok(ResidueType::Serine),
-            "THR" => Ok(ResidueType::Threonine),
-            "MET" => Ok(ResidueType::Methionine),
-            "ARG" => Ok(ResidueType::Arginine),
-            "LYS" => Ok(ResidueType::Lysine),
-            "ASP" => Ok(ResidueType::AsparticAcid),
-            "GLU" => Ok(ResidueType::GlutamicAcid),
-            "HIS" => Ok(ResidueType::Histidine),
-            "HSE" => Ok(ResidueType::HistidineEpsilon),
-            "HSP" => Ok(ResidueType::HistidineProtonated),
-            unsupported => Err(ParseResidueTypeError(unsupported.to_string())),
-        }
+        ResidueType::from_str_optional(s)
+            .ok_or_else(|| ParseResidueTypeError(s.trim().to_uppercase()))
     }
 }
 
 impl ResidueType {
-    pub fn from_str_optional(s: &str) -> Option<Self> {
+    fn parse_code(s: &str) -> Option<Self> {
         match s.trim().to_uppercase().as_str() {
             "ALA" => Some(ResidueType::Alanine),
             "GLY" => Some(ResidueType::Glycine),
@@ -102,6 +79,10 @@ impl ResidueType {
             "HSP" => Some(ResidueType::HistidineProtonated),
             _ => None,
         }
+    }
+
+    pub fn from_str_optional(s: &str) -> Option<Self> {
+        Self::parse_code(s)
     }
 
     pub fn to_three_letter(self) -> &'static str {

--- a/crates/scream-core/src/core/models/residue.rs
+++ b/crates/scream-core/src/core/models/residue.rs
@@ -136,14 +136,19 @@ impl ResidueType {
 pub struct Residue {
     pub id: isize,                          // Residue sequence number from source file
     pub name: String,                       // Name of the residue (e.g., "ALA", "GLY")
-    pub res_type: ResidueType,              // Type of the residue (e.g., Alanine, Glycine)
+    pub res_type: Option<ResidueType>,      // Optional residue type (e.g., Alanine, Glycine)
     pub chain_id: ChainId,                  // ID of the parent chain
     pub(crate) atoms: Vec<AtomId>,          // Indices of atoms belonging to this residue
     atom_name_map: HashMap<String, AtomId>, // Map from atom name to its stable ID
 }
 
 impl Residue {
-    pub(crate) fn new(id: isize, name: &str, res_type: ResidueType, chain_id: ChainId) -> Self {
+    pub(crate) fn new(
+        id: isize,
+        name: &str,
+        res_type: Option<ResidueType>,
+        chain_id: ChainId,
+    ) -> Self {
         Self {
             id,
             name: name.to_string(),
@@ -221,7 +226,7 @@ mod tests {
 
     #[test]
     fn residue_adds_and_retrieves_atoms_by_name() {
-        let mut residue = Residue::new(1, "ALA", ResidueType::Alanine, dummy_chain_id(0));
+        let mut residue = Residue::new(1, "ALA", Some(ResidueType::Alanine), dummy_chain_id(0));
         let atom_id = dummy_atom_id(42);
         residue.add_atom("CA", atom_id);
         assert_eq!(residue.atoms(), &[atom_id]);
@@ -230,7 +235,7 @@ mod tests {
 
     #[test]
     fn residue_removes_atom_by_name_and_id() {
-        let mut residue = Residue::new(2, "GLY", ResidueType::Glycine, dummy_chain_id(1));
+        let mut residue = Residue::new(2, "GLY", Some(ResidueType::Glycine), dummy_chain_id(1));
         let atom_id1 = dummy_atom_id(1);
         let atom_id2 = dummy_atom_id(2);
         residue.add_atom("N", atom_id1);
@@ -243,13 +248,13 @@ mod tests {
 
     #[test]
     fn residue_get_atom_id_by_name_returns_none_for_unknown_atom() {
-        let residue = Residue::new(3, "SER", ResidueType::Serine, dummy_chain_id(2));
+        let residue = Residue::new(3, "SER", Some(ResidueType::Serine), dummy_chain_id(2));
         assert_eq!(residue.get_atom_id_by_name("CB"), None);
     }
 
     #[test]
     fn residue_atoms_returns_empty_slice_when_no_atoms() {
-        let residue = Residue::new(4, "THR", ResidueType::Threonine, dummy_chain_id(3));
+        let residue = Residue::new(4, "THR", Some(ResidueType::Threonine), dummy_chain_id(3));
         assert!(residue.atoms().is_empty());
     }
 }

--- a/crates/scream-core/src/core/models/residue.rs
+++ b/crates/scream-core/src/core/models/residue.rs
@@ -1,5 +1,44 @@
 use super::ids::{AtomId, ChainId};
 use std::collections::HashMap;
+use std::str::FromStr;
+use thiserror::Error;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum AminoAcidType {
+    // --- Aliphatic, Nonpolar ---
+    Alanine,    // Alanine (ALA)
+    Glycine,    // Glycine (GLY)
+    Isoleucine, // Isoleucine (ILE)
+    Leucine,    // Leucine (LEU)
+    Proline,    // Proline (PRO)
+    Valine,     // Valine (VAL)
+
+    // --- Aromatic ---
+    Phenylalanine, // Phenylalanine (PHE)
+    Tryptophan,    // Tryptophan (TRP)
+    Tyrosine,      // Tyrosine (TYR)
+
+    // --- Polar, Uncharged ---
+    Asparagine, // Asparagine (ASN)
+    Cysteine,   // Cysteine (CYS)
+    Glutamine,  // Glutamine (GLN)
+    Serine,     // Serine (SER)
+    Threonine,  // Threonine (THR)
+    Methionine, // Methionine (MET)
+
+    // --- Positively Charged (Basic) ---
+    Arginine, // Arginine (ARG)
+    Lysine,   // Lysine (LYS)
+
+    // --- Negatively Charged (Acidic) ---
+    AsparticAcid, // Aspartic Acid (ASP)
+    GlutamicAcid, // Glutamic Acid (GLU)
+
+    // --- Special Case: Histidine and its Variants ---
+    Histidine, // Histidine (HIS) - Typically assumed to be the Epsilon-protonated state (HSE)
+    HistidineEpsilon, // Epsilon-protonated Histidine (HSE) - An alias for `Histidine`
+    HistidineProtonated, // Doubly-protonated Histidine (HSP) - The positively charged variant
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Residue {

--- a/crates/scream-core/src/core/models/residue.rs
+++ b/crates/scream-core/src/core/models/residue.rs
@@ -208,6 +208,12 @@ mod tests {
     }
 
     #[test]
+    fn from_str_optional_returns_none_for_unknown_code() {
+        assert!(ResidueType::from_str_optional("XYZ").is_none());
+        assert!(ResidueType::from_str_optional("unknown").is_none());
+    }
+
+    #[test]
     fn to_three_letter_returns_correct_code() {
         assert_eq!(ResidueType::Alanine.to_three_letter(), "ALA");
         assert_eq!(ResidueType::HistidineProtonated.to_three_letter(), "HSP");

--- a/crates/scream-core/src/core/models/system.rs
+++ b/crates/scream-core/src/core/models/system.rs
@@ -84,7 +84,7 @@ impl MolecularSystem {
         chain_id: ChainId,
         res_seq: isize,
         name: &str,
-        res_type: ResidueType,
+        res_type: Option<ResidueType>,
     ) -> Option<ResidueId> {
         let chain = self.chains.get_mut(chain_id)?;
         let key = (chain_id, res_seq);
@@ -201,7 +201,7 @@ mod tests {
         let chain_a_id = system.add_chain('A', ChainType::Protein);
 
         let gly_id = system
-            .add_residue(chain_a_id, 1, "GLY", ResidueType::Glycine)
+            .add_residue(chain_a_id, 1, "GLY", Some(ResidueType::Glycine))
             .unwrap();
         let n_atom = Atom::new(1, "N", gly_id, Point3::new(0.0, 0.0, 0.0));
         let ca_atom = Atom::new(2, "CA", gly_id, Point3::new(1.4, 0.0, 0.0));
@@ -210,7 +210,7 @@ mod tests {
         system.add_bond(n_id, ca_id, BondOrder::Single).unwrap();
 
         let ala_id = system
-            .add_residue(chain_a_id, 2, "ALA", ResidueType::Alanine)
+            .add_residue(chain_a_id, 2, "ALA", Some(ResidueType::Alanine))
             .unwrap();
         let ala_ca_atom = Atom::new(3, "CA", ala_id, Point3::new(2.0, 1.0, 0.0));
         system.add_atom_to_residue(ala_id, ala_ca_atom).unwrap();
@@ -315,11 +315,11 @@ mod tests {
         assert_eq!(system.residue(gly_id).unwrap().name, "GLY");
         assert_eq!(
             system.residue(gly_id).unwrap().res_type,
-            ResidueType::Glycine
+            Some(ResidueType::Glycine)
         );
         assert_eq!(
             system.residue(ala_id).unwrap().res_type,
-            ResidueType::Alanine
+            Some(ResidueType::Alanine)
         );
     }
 }

--- a/crates/scream-core/src/core/models/system.rs
+++ b/crates/scream-core/src/core/models/system.rs
@@ -1,7 +1,7 @@
 use super::atom::Atom;
 use super::chain::{Chain, ChainType};
 use super::ids::{AtomId, ChainId, ResidueId};
-use super::residue::Residue;
+use super::residue::{Residue, ResidueType};
 use super::topology::{Bond, BondOrder};
 use slotmap::{SecondaryMap, SlotMap};
 use std::collections::HashMap;
@@ -84,11 +84,12 @@ impl MolecularSystem {
         chain_id: ChainId,
         res_seq: isize,
         name: &str,
+        res_type: ResidueType,
     ) -> Option<ResidueId> {
         let chain = self.chains.get_mut(chain_id)?;
         let key = (chain_id, res_seq);
         let residue_id = *self.residue_id_map.entry(key).or_insert_with(|| {
-            let residue = Residue::new(res_seq, name, chain_id);
+            let residue = Residue::new(res_seq, name, res_type, chain_id);
             self.residues.insert(residue)
         });
 
@@ -191,6 +192,7 @@ impl MolecularSystem {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::models::residue::ResidueType;
     use nalgebra::Point3;
 
     fn create_test_system() -> MolecularSystem {
@@ -198,16 +200,20 @@ mod tests {
 
         let chain_a_id = system.add_chain('A', ChainType::Protein);
 
-        let gly_id = system.add_residue(chain_a_id, 1, "GLY").unwrap();
+        let gly_id = system
+            .add_residue(chain_a_id, 1, "GLY", ResidueType::Glycine)
+            .unwrap();
         let n_atom = Atom::new(1, "N", gly_id, Point3::new(0.0, 0.0, 0.0));
         let ca_atom = Atom::new(2, "CA", gly_id, Point3::new(1.4, 0.0, 0.0));
         let n_id = system.add_atom_to_residue(gly_id, n_atom).unwrap();
         let ca_id = system.add_atom_to_residue(gly_id, ca_atom).unwrap();
-        system.add_bond(n_id, ca_id, BondOrder::Single);
+        system.add_bond(n_id, ca_id, BondOrder::Single).unwrap();
 
-        let ala_id = system.add_residue(chain_a_id, 2, "ALA").unwrap();
+        let ala_id = system
+            .add_residue(chain_a_id, 2, "ALA", ResidueType::Alanine)
+            .unwrap();
         let ala_ca_atom = Atom::new(3, "CA", ala_id, Point3::new(2.0, 1.0, 0.0));
-        system.add_atom_to_residue(ala_id, ala_ca_atom);
+        system.add_atom_to_residue(ala_id, ala_ca_atom).unwrap();
 
         system
     }
@@ -263,7 +269,6 @@ mod tests {
         assert_eq!(system.residue(gly_id).unwrap().atoms().len(), 1);
         assert!(!system.residue(gly_id).unwrap().atoms().contains(&atom_n_id));
     }
-
     #[test]
     fn residue_removal_updates_system_correctly() {
         let mut system = create_test_system();
@@ -297,6 +302,24 @@ mod tests {
                 .unwrap()
                 .residues()
                 .contains(&gly_id)
+        );
+    }
+
+    #[test]
+    fn system_creation_and_access_with_residue_type() {
+        let system = create_test_system();
+        let chain_a_id = system.find_chain_by_id('A').unwrap();
+        let gly_id = system.find_residue_by_id(chain_a_id, 1).unwrap();
+        let ala_id = system.find_residue_by_id(chain_a_id, 2).unwrap();
+
+        assert_eq!(system.residue(gly_id).unwrap().name, "GLY");
+        assert_eq!(
+            system.residue(gly_id).unwrap().res_type,
+            ResidueType::Glycine
+        );
+        assert_eq!(
+            system.residue(ala_id).unwrap().res_type,
+            ResidueType::Alanine
         );
     }
 }

--- a/crates/scream-core/src/core/utils/geometry.rs
+++ b/crates/scream-core/src/core/utils/geometry.rs
@@ -15,3 +15,27 @@ pub fn rotation_to_align(from: &Vector3<f64>, to: &Vector3<f64>) -> Option<Rotat
 pub fn rotation_from_axis_angle(axis: &Vector3<f64>, angle_degrees: f64) -> Rotation3<f64> {
     Rotation3::from_axis_angle(&Unit::new_normalize(*axis), angle_degrees.to_radians())
 }
+
+pub fn calculate_cb_position(
+    n_pos: &Point3<f64>,
+    ca_pos: &Point3<f64>,
+    c_pos: &Point3<f64>,
+    params: &CbCreationParams,
+) -> Point3<f64> {
+    let ca_n = (n_pos - ca_pos).normalize();
+    let ca_c = (c_pos - ca_pos).normalize();
+
+    let bisector = -(ca_n + ca_c).normalize();
+    let plane_normal = Unit::new_normalize(ca_n.cross(&ca_c));
+
+    let rot_off_bisector =
+        Rotation3::from_axis_angle(&plane_normal, params.off_bisector_angle.to_radians());
+    let cb_vec_in_plane = rot_off_bisector * bisector;
+
+    let in_plane_axis = Unit::new_normalize(cb_vec_in_plane);
+    let rot_off_plane =
+        Rotation3::from_axis_angle(&in_plane_axis, params.off_plane_angle.to_radians());
+    let final_cb_vec = rot_off_plane * cb_vec_in_plane;
+
+    ca_pos + final_cb_vec * params.bond_length
+}

--- a/crates/scream-core/src/core/utils/geometry.rs
+++ b/crates/scream-core/src/core/utils/geometry.rs
@@ -53,3 +53,66 @@ pub fn calculate_hn_position(
 
     n_pos + hn_dir * bond_length
 }
+
+pub fn generate_sp3_hydrogens(
+    base_pos: &Point3<f64>,
+    neighbors: &[Point3<f64>],
+    bond_length: f64,
+) -> Vec<Point3<f64>> {
+    let neighbor_vecs: Vec<Vector3<f64>> = neighbors
+        .iter()
+        .map(|p| (p - base_pos).normalize())
+        .collect();
+
+    match neighbor_vecs.len() {
+        1 => {
+            let n1 = neighbor_vecs[0];
+            let mut temp_vec = if n1.x.abs() < 0.9 {
+                Vector3::x()
+            } else {
+                Vector3::y()
+            };
+            temp_vec = (temp_vec - n1 * n1.dot(&temp_vec)).normalize();
+
+            let rot_axis = Unit::new_normalize(n1);
+            let rot = Rotation3::from_axis_angle(&rot_axis, 120.0f64.to_radians());
+
+            let h1_dir = Rotation3::from_axis_angle(
+                &Unit::new_normalize(n1.cross(&temp_vec)),
+                109.5f64.to_radians(),
+            ) * n1;
+            let h1 = base_pos + h1_dir.normalize() * bond_length;
+            let h2 = base_pos + (rot * (h1 - base_pos));
+            let h3 = base_pos + (rot * (h2 - base_pos));
+            vec![h1, h2, h3]
+        }
+        2 => {
+            let n1 = neighbor_vecs[0];
+            let n2 = neighbor_vecs[1];
+            let bisector = (n1 + n2).normalize();
+            let cross_prod = n1.cross(&n2).normalize();
+
+            let h_dir_base = cross_prod.cross(&bisector).normalize();
+            let rot = Rotation3::from_axis_angle(
+                &Unit::new_normalize(bisector),
+                109.5f64.to_radians() / 2.0,
+            );
+
+            let h1 = base_pos + (rot * h_dir_base) * bond_length;
+            let h2 = base_pos
+                + (Rotation3::from_axis_angle(
+                    &Unit::new_normalize(bisector),
+                    -109.5f64.to_radians(),
+                ) * (h1 - base_pos));
+            vec![h1, h2]
+        }
+        3 => {
+            let n1 = neighbor_vecs[0];
+            let n2 = neighbor_vecs[1];
+            let n3 = neighbor_vecs[2];
+            let h_dir = -(n1 + n2 + n3).normalize();
+            vec![base_pos + h_dir * bond_length]
+        }
+        _ => panic!("generate_sp3_hydrogens expects 1, 2, or 3 neighbors."),
+    }
+}

--- a/crates/scream-core/src/core/utils/geometry.rs
+++ b/crates/scream-core/src/core/utils/geometry.rs
@@ -11,3 +11,7 @@ pub struct CbCreationParams {
 pub fn rotation_to_align(from: &Vector3<f64>, to: &Vector3<f64>) -> Option<Rotation3<f64>> {
     Rotation3::rotation_between(from, to)
 }
+
+pub fn rotation_from_axis_angle(axis: &Vector3<f64>, angle_degrees: f64) -> Rotation3<f64> {
+    Rotation3::from_axis_angle(&Unit::new_normalize(*axis), angle_degrees.to_radians())
+}

--- a/crates/scream-core/src/core/utils/geometry.rs
+++ b/crates/scream-core/src/core/utils/geometry.rs
@@ -1,0 +1,10 @@
+use nalgebra::{Point3, Rotation3, Unit, Vector3};
+use std::collections::HashMap;
+use std::f64::consts::PI;
+
+#[derive(Debug, Clone, Copy)]
+pub struct CbCreationParams {
+    pub off_bisector_angle: f64, // Angle offset from the C-N-CA bisector (in degrees)
+    pub off_plane_angle: f64,    // Angle offset from the C-N-CA plane (in degrees)
+    pub bond_length: f64,        // The desired CA-CB bond length
+}

--- a/crates/scream-core/src/core/utils/geometry.rs
+++ b/crates/scream-core/src/core/utils/geometry.rs
@@ -116,3 +116,16 @@ pub fn generate_sp3_hydrogens(
         _ => panic!("generate_sp3_hydrogens expects 1, 2, or 3 neighbors."),
     }
 }
+
+pub fn calculate_rmsd(coords1: &[Point3<f64>], coords2: &[Point3<f64>]) -> Option<f64> {
+    if coords1.len() != coords2.len() || coords1.is_empty() {
+        return None;
+    }
+    let n = coords1.len() as f64;
+    let squared_dist_sum: f64 = coords1
+        .iter()
+        .zip(coords2.iter())
+        .map(|(p1, p2)| (p1 - p2).norm_squared())
+        .sum();
+    Some((squared_dist_sum / n).sqrt())
+}

--- a/crates/scream-core/src/core/utils/geometry.rs
+++ b/crates/scream-core/src/core/utils/geometry.rs
@@ -129,3 +129,23 @@ pub fn calculate_rmsd(coords1: &[Point3<f64>], coords2: &[Point3<f64>]) -> Optio
         .sum();
     Some((squared_dist_sum / n).sqrt())
 }
+
+pub fn calculate_named_rmsd(
+    coords1: &HashMap<String, Point3<f64>>,
+    coords2: &HashMap<String, Point3<f64>>,
+) -> Option<f64> {
+    let mut squared_dist_sum = 0.0;
+    let mut count = 0;
+
+    for (name, p1) in coords1 {
+        if let Some(p2) = coords2.get(name) {
+            squared_dist_sum += (p1 - p2).norm_squared();
+            count += 1;
+        }
+    }
+    if count == 0 {
+        None
+    } else {
+        Some((squared_dist_sum / count as f64).sqrt())
+    }
+}

--- a/crates/scream-core/src/core/utils/geometry.rs
+++ b/crates/scream-core/src/core/utils/geometry.rs
@@ -149,3 +149,22 @@ pub fn calculate_named_rmsd(
         Some((squared_dist_sum / count as f64).sqrt())
     }
 }
+
+pub fn find_max_atom_deviation<'a>(
+    coords1: &'a HashMap<String, Point3<f64>>,
+    coords2: &'a HashMap<String, Point3<f64>>,
+) -> Option<(f64, &'a str)> {
+    coords1
+        .iter()
+        .filter_map(|(name, p1)| {
+            coords2.get(name).map(|p2| {
+                let dist = (p1 - p2).norm();
+                (dist, name.as_str())
+            })
+        })
+        .max_by(|(dist1, _), (dist2, _)| {
+            dist1
+                .partial_cmp(dist2)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        })
+}

--- a/crates/scream-core/src/core/utils/geometry.rs
+++ b/crates/scream-core/src/core/utils/geometry.rs
@@ -363,7 +363,7 @@ mod tests {
     fn generate_sp3_hydrogens_panics_on_invalid_count() {
         let base_pos = Point3::new(0.0, 0.0, 0.0);
         let neighbors = [];
-        generate_sp3_hydrogens(&base_pos, &neighbors, 1.0);
+        generate_sp3_hydrogens(&base_pos, &neighbors, 1.0).unwrap();
     }
 
     #[test]

--- a/crates/scream-core/src/core/utils/geometry.rs
+++ b/crates/scream-core/src/core/utils/geometry.rs
@@ -1,10 +1,9 @@
 use nalgebra::{Point3, Rotation3, Unit, Vector3};
 use std::collections::HashMap;
-use std::f64::consts::PI;
 
 #[derive(Debug, Clone, Copy)]
 pub struct CbCreationParams {
-    pub off_bisector_angle: f64, // Angle offset from the C-N-CA bisector (in degrees)
-    pub off_plane_angle: f64,    // Angle offset from the C-N-CA plane (in degrees)
-    pub bond_length: f64,        // The desired CA-CB bond length
+    pub off_bisector_angle: f64,
+    pub off_plane_angle: f64,
+    pub bond_length: f64,
 }

--- a/crates/scream-core/src/core/utils/geometry.rs
+++ b/crates/scream-core/src/core/utils/geometry.rs
@@ -8,6 +8,28 @@ pub struct CbCreationParams {
     pub bond_length: f64,
 }
 
+pub fn dihedral_angle(
+    p1: &Point3<f64>,
+    p2: &Point3<f64>,
+    p3: &Point3<f64>,
+    p4: &Point3<f64>,
+) -> f64 {
+    let b1 = p1 - p2;
+    let b2 = p3 - p2;
+    let b3 = p4 - p3;
+
+    let n1 = b1.cross(&b2);
+    let n2 = b2.cross(&b3);
+
+    let angle_rad = n1.angle(&n2);
+
+    if n1.cross(&n2).dot(&b2) < 0.0 {
+        -angle_rad.to_degrees()
+    } else {
+        angle_rad.to_degrees()
+    }
+}
+
 pub fn rotation_to_align(from: &Vector3<f64>, to: &Vector3<f64>) -> Option<Rotation3<f64>> {
     Rotation3::rotation_between(from, to)
 }
@@ -182,28 +204,6 @@ mod tests {
 
     fn f64_approx_equal(a: f64, b: f64) -> bool {
         (a - b).abs() < EPSILON
-    }
-
-    pub fn dihedral_angle(
-        p1: &Point3<f64>,
-        p2: &Point3<f64>,
-        p3: &Point3<f64>,
-        p4: &Point3<f64>,
-    ) -> f64 {
-        let b1 = p1 - p2;
-        let b2 = p3 - p2;
-        let b3 = p4 - p3;
-
-        let n1 = b1.cross(&b2);
-        let n2 = b2.cross(&b3);
-
-        let angle_rad = n1.angle(&n2);
-
-        if n1.cross(&n2).dot(&b2) < 0.0 {
-            -angle_rad.to_degrees()
-        } else {
-            angle_rad.to_degrees()
-        }
     }
 
     #[test]

--- a/crates/scream-core/src/core/utils/geometry.rs
+++ b/crates/scream-core/src/core/utils/geometry.rs
@@ -7,3 +7,7 @@ pub struct CbCreationParams {
     pub off_plane_angle: f64,
     pub bond_length: f64,
 }
+
+pub fn rotation_to_align(from: &Vector3<f64>, to: &Vector3<f64>) -> Option<Rotation3<f64>> {
+    Rotation3::rotation_between(from, to)
+}

--- a/crates/scream-core/src/core/utils/geometry.rs
+++ b/crates/scream-core/src/core/utils/geometry.rs
@@ -39,3 +39,17 @@ pub fn calculate_cb_position(
 
     ca_pos + final_cb_vec * params.bond_length
 }
+
+pub fn calculate_hn_position(
+    n_pos: &Point3<f64>,
+    ca_pos: &Point3<f64>,
+    prev_c_pos: &Point3<f64>,
+    bond_length: f64,
+) -> Point3<f64> {
+    let n_ca = (ca_pos - n_pos).normalize();
+    let n_c_prev = (prev_c_pos - n_pos).normalize();
+
+    let hn_dir = -(n_ca + n_c_prev).normalize();
+
+    n_pos + hn_dir * bond_length
+}

--- a/crates/scream-core/src/core/utils/identifiers.rs
+++ b/crates/scream-core/src/core/utils/identifiers.rs
@@ -1,0 +1,127 @@
+use phf::{Map, Set, phf_map, phf_set};
+use std::cmp::Ordering;
+use thiserror::Error;
+
+static BACKBONE_ATOM_NAMES: Set<&'static str> = phf_set! {
+    // Standard backbone
+    "N", "H", "HN", "CA", "HA", "C", "O",
+    // N-Terminus variants
+    "H1", "H2", "H3", "NT", "HT1", "HT2", "HT3",
+    // C-Terminus variants
+    "OXT", "OT1", "OT2", "HC", "HOXT",
+    // Glycine alpha-hydrogens
+    "HA1", "HA2", "1HA", "2HA",
+};
+
+static STANDARD_AMINO_ACID_NAMES: Set<&'static str> = phf_set! {
+    "ALA", "ARG", "ASN", "ASP", "CYS", "GLN", "GLU", "GLY", "HIS",
+    "HSE", "HSP", "HSD", "ILE", "LEU", "LYS", "MET", "PHE", "PRO",
+    "SER", "THR", "TRP", "TYR", "VAL", "CYX", "LYN", "ARN", "APP", "GLP",
+};
+
+static THREE_TO_ONE_CODE: Map<&'static str, char> = phf_map! {
+    "ALA" => 'A', "ARG" => 'R', "ASN" => 'N', "ASP" => 'D',
+    "CYS" => 'C', "GLN" => 'Q', "GLU" => 'E', "GLY" => 'G',
+    "HIS" => 'H', "ILE" => 'I', "LEU" => 'L', "LYS" => 'K',
+    "MET" => 'M', "PHE" => 'F', "PRO" => 'P', "SER" => 'S',
+    "THR" => 'T', "TRP" => 'W', "TYR" => 'Y', "VAL" => 'V',
+    "CYX" => 'C', "HSE" => 'H', "HSP" => 'B', "HSD" => 'J',
+    "LYN" => 'K', "ARN" => 'R', "APP" => 'A', "GLP" => 'Q',
+};
+
+static ONE_TO_THREE_CODE: Map<char, &'static str> = phf_map! {
+    'A' => "ALA", 'R' => "ARG", 'N' => "ASN", 'D' => "ASP",
+    'C' => "CYS", 'Q' => "GLN", 'E' => "GLU", 'G' => "GLY",
+    'H' => "HIS", 'I' => "ILE", 'L' => "LEU", 'K' => "LYS",
+    'M' => "MET", 'F' => "PHE", 'P' => "PRO", 'S' => "SER",
+    'T' => "THR", 'W' => "TRP", 'Y' => "TYR", 'V' => "VAL",
+};
+
+static ATOM_ORDER_WEIGHTS: Map<&'static str, i32> = phf_map! {
+    "N"    => 10, "NT"   => 10,
+    "HN"   => 20, "H1"   => 20, "H2"   => 21, "H3"   => 22,
+    "HN1"  => 20, "HN2"  => 21, "HN3"  => 22,
+    "HT1"  => 20, "HT2"  => 21, "HT3"  => 22,
+    "CA"   => 30,
+    "HA"   => 40, "HCA"  => 40, "HA1"  => 41, "HA2"  => 42, "1HA" => 41, "2HA" => 42,
+    "CB"   => 110,
+    "HB"   => 120, "HCB"  => 120, "HB1"  => 121, "HB2"  => 122, "HB3"  => 123,
+    "CG"   => 210, "CG1"  => 211, "CG2"  => 212, "SG"   => 213, "OG"   => 214, "OG1"  => 215,
+    "HG"   => 220, "HCG"  => 220, "HG1"  => 221, "HG2"  => 222, "HSG"  => 223, "HOG"  => 224, "HOG1" => 225,
+    "CD"   => 310, "CD1"  => 311, "CD2"  => 312, "SD"   => 313, "OD1"  => 314, "OD2"  => 315, "ND1"  => 316, "ND2"  => 317,
+    "HD1"  => 321, "HD2"  => 322, "HCD"  => 320, "HCD1" => 321, "HCD2" => 322, "HOD1" => 324, "HND1" => 326, "HND2" => 327,
+    "CE"   => 410, "CE1"  => 411, "CE2"  => 412, "CE3"  => 413, "NE"   => 414, "NE1"  => 415, "NE2"  => 416, "OE1"  => 417, "OE2"  => 418,
+    "HE1"  => 421, "HE2"  => 422, "HE3"  => 423, "HCE"  => 420, "HCE1" => 421, "HCE2" => 422, "HCE3" => 423, "HNE"  => 424, "HNE1" => 425, "HNE2" => 426, "HOE1" => 427,
+    "CZ"   => 510, "CZ2"  => 512, "CZ3"  => 513, "NZ"   => 514, "OH"   => 515,
+    "HZ"   => 520, "HCZ"  => 520, "HH"   => 525, "HOH"  => 525,
+    "CH2"  => 610,
+    "HH2"  => 620, "HCH2" => 620,
+    "NH1"  => 710, "NH2"  => 711,
+    "HH11" => 721, "HH12" => 722, "HH21" => 723, "HH22" => 724,
+    "C"    => 8000,
+    "O"    => 9000,
+    "OXT"  => 9001, "OT1"  => 9001, "OT2"  => 9002,
+};
+
+pub fn is_backbone_atom(atom_name: &str) -> bool {
+    BACKBONE_ATOM_NAMES.contains(atom_name.trim())
+}
+
+pub fn is_sidechain_atom(atom_name: &str) -> bool {
+    !is_backbone_atom(atom_name)
+}
+
+pub fn is_heavy_atom(atom_name: &str) -> bool {
+    !atom_name.trim().starts_with('H')
+}
+
+pub fn is_standard_amino_acid(residue_name: &str) -> bool {
+    STANDARD_AMINO_ACID_NAMES.contains(residue_name.trim())
+}
+
+pub fn three_to_one_letter_code(three_letter: &str) -> Option<char> {
+    THREE_TO_ONE_CODE.get(three_letter.trim()).copied()
+}
+
+pub fn one_to_three_letter_code(one_letter: char) -> Option<&'static str> {
+    ONE_TO_THREE_CODE.get(&one_letter).copied()
+}
+
+pub fn residue_atom_order(atom1_name: &str, atom2_name: &str) -> Ordering {
+    let weight1 = ATOM_ORDER_WEIGHTS
+        .get(atom1_name.trim())
+        .unwrap_or(&i32::MAX);
+    let weight2 = ATOM_ORDER_WEIGHTS
+        .get(atom2_name.trim())
+        .unwrap_or(&i32::MAX);
+    weight1.cmp(weight2)
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum ParseMutationInfoError {
+    #[error("Invalid format for mutation info string: '{0}'")]
+    InvalidFormat(String),
+    #[error("Residue ID part is not a valid number in string: '{0}'")]
+    InvalidResidueId(String),
+}
+
+pub fn parse_mutation_info(s: &str) -> Result<(char, isize, char), ParseMutationInfoError> {
+    let trimmed = s.trim();
+    if trimmed.len() < 4 || !trimmed.contains('_') {
+        return Err(ParseMutationInfoError::InvalidFormat(s.to_string()));
+    }
+
+    let aa = trimmed.chars().next().unwrap();
+    let chain_id = trimmed.chars().last().unwrap();
+
+    let parts: Vec<_> = trimmed[1..trimmed.len() - 1].split('_').collect();
+    if parts.len() != 2 || !parts[1].is_empty() {
+        return Err(ParseMutationInfoError::InvalidFormat(s.to_string()));
+    }
+
+    let res_id: isize = parts[0]
+        .parse()
+        .map_err(|_| ParseMutationInfoError::InvalidResidueId(parts[0].to_string()))?;
+
+    Ok((aa, res_id, chain_id))
+}

--- a/crates/scream-core/src/core/utils/identifiers.rs
+++ b/crates/scream-core/src/core/utils/identifiers.rs
@@ -1,90 +1,39 @@
 use phf::{Map, Set, phf_map, phf_set};
 use std::cmp::Ordering;
-use thiserror::Error;
 
 static BACKBONE_ATOM_NAMES: Set<&'static str> = phf_set! {
-    // Standard backbone
-    "N", "H", "HN", "CA", "HA", "C", "O",
-    // N-Terminus variants
-    "H1", "H2", "H3", "NT", "HT1", "HT2", "HT3",
-    // C-Terminus variants
-    "OXT", "OT1", "OT2", "HC", "HOXT",
-    // Glycine alpha-hydrogens
-    "HA1", "HA2", "1HA", "2HA",
-};
-
-static STANDARD_AMINO_ACID_NAMES: Set<&'static str> = phf_set! {
-    "ALA", "ARG", "ASN", "ASP", "CYS", "GLN", "GLU", "GLY", "HIS",
-    "HSE", "HSP", "HSD", "ILE", "LEU", "LYS", "MET", "PHE", "PRO",
-    "SER", "THR", "TRP", "TYR", "VAL", "CYX", "LYN", "ARN", "APP", "GLP",
-};
-
-static THREE_TO_ONE_CODE: Map<&'static str, char> = phf_map! {
-    "ALA" => 'A', "ARG" => 'R', "ASN" => 'N', "ASP" => 'D',
-    "CYS" => 'C', "GLN" => 'Q', "GLU" => 'E', "GLY" => 'G',
-    "HIS" => 'H', "ILE" => 'I', "LEU" => 'L', "LYS" => 'K',
-    "MET" => 'M', "PHE" => 'F', "PRO" => 'P', "SER" => 'S',
-    "THR" => 'T', "TRP" => 'W', "TYR" => 'Y', "VAL" => 'V',
-    "CYX" => 'C', "HSE" => 'H', "HSP" => 'B', "HSD" => 'J',
-    "LYN" => 'K', "ARN" => 'R', "APP" => 'A', "GLP" => 'Q',
-};
-
-static ONE_TO_THREE_CODE: Map<char, &'static str> = phf_map! {
-    'A' => "ALA", 'R' => "ARG", 'N' => "ASN", 'D' => "ASP",
-    'C' => "CYS", 'Q' => "GLN", 'E' => "GLU", 'G' => "GLY",
-    'H' => "HIS", 'I' => "ILE", 'L' => "LEU", 'K' => "LYS",
-    'M' => "MET", 'F' => "PHE", 'P' => "PRO", 'S' => "SER",
-    'T' => "THR", 'W' => "TRP", 'Y' => "TYR", 'V' => "VAL",
+    "N", "H", "HN", "CA", "HA", "C", "O", "OXT", "H1", "H2", "H3", "NT",
+    "HT1", "HT2", "HT3", "OT1", "OT2", "HC", "HOXT", "HA1", "HA2", "1HA", "2HA",
 };
 
 static ATOM_ORDER_WEIGHTS: Map<&'static str, i32> = phf_map! {
-    "N"    => 10, "NT"   => 10,
-    "HN"   => 20, "H1"   => 20, "H2"   => 21, "H3"   => 22,
-    "HN1"  => 20, "HN2"  => 21, "HN3"  => 22,
-    "HT1"  => 20, "HT2"  => 21, "HT3"  => 22,
-    "CA"   => 30,
-    "HA"   => 40, "HCA"  => 40, "HA1"  => 41, "HA2"  => 42, "1HA" => 41, "2HA" => 42,
-    "CB"   => 110,
-    "HB"   => 120, "HCB"  => 120, "HB1"  => 121, "HB2"  => 122, "HB3"  => 123,
-    "CG"   => 210, "CG1"  => 211, "CG2"  => 212, "SG"   => 213, "OG"   => 214, "OG1"  => 215,
-    "HG"   => 220, "HCG"  => 220, "HG1"  => 221, "HG2"  => 222, "HSG"  => 223, "HOG"  => 224, "HOG1" => 225,
-    "CD"   => 310, "CD1"  => 311, "CD2"  => 312, "SD"   => 313, "OD1"  => 314, "OD2"  => 315, "ND1"  => 316, "ND2"  => 317,
-    "HD1"  => 321, "HD2"  => 322, "HCD"  => 320, "HCD1" => 321, "HCD2" => 322, "HOD1" => 324, "HND1" => 326, "HND2" => 327,
-    "CE"   => 410, "CE1"  => 411, "CE2"  => 412, "CE3"  => 413, "NE"   => 414, "NE1"  => 415, "NE2"  => 416, "OE1"  => 417, "OE2"  => 418,
-    "HE1"  => 421, "HE2"  => 422, "HE3"  => 423, "HCE"  => 420, "HCE1" => 421, "HCE2" => 422, "HCE3" => 423, "HNE"  => 424, "HNE1" => 425, "HNE2" => 426, "HOE1" => 427,
-    "CZ"   => 510, "CZ2"  => 512, "CZ3"  => 513, "NZ"   => 514, "OH"   => 515,
-    "HZ"   => 520, "HCZ"  => 520, "HH"   => 525, "HOH"  => 525,
-    "CH2"  => 610,
-    "HH2"  => 620, "HCH2" => 620,
-    "NH1"  => 710, "NH2"  => 711,
-    "HH11" => 721, "HH12" => 722, "HH21" => 723, "HH22" => 724,
-    "C"    => 8000,
-    "O"    => 9000,
-    "OXT"  => 9001, "OT1"  => 9001, "OT2"  => 9002,
+    "N" => 10, "NT" => 10,
+    "HN" => 20, "HN1" => 21, "HN2" => 22, "HN3" => 23, "H1" => 20, "H2" => 21, "H3" => 22,
+    "CA" => 30,
+    "HCA" => 40, "HA" => 40, "HA1" => 41, "HA2" => 42, "1HA" => 41, "2HA" => 42,
+    "CB" => 110,
+    "HB" => 120, "HCB" => 120, "HB1" => 121, "HB2" => 122, "HB3" => 123,
+    "CG" => 210, "OG1" => 220, "CG1" => 230, "CG2" => 250, "SG" => 270, "OG" => 290,
+    "HCG" => 215, "HOG1" => 225, "HCG1" => 240, "HCG2" => 260, "HSG" => 280, "HOG" => 300,
+    "CD" => 310, "ND1" => 330, "CD1" => 350, "CD2" => 370, "OD1" => 390, "OD2" => 400, "ND2" => 410, "SD" => 430,
+    "HCD" => 320, "HND1" => 340, "HCD1" => 360, "HCD2" => 380, "HOD1" => 391, "HOD2" => 401, "HND2" => 420, "HSD" => 431,
+    "CE" => 510, "NE" => 530, "NE1" => 550, "CE1" => 570, "OE1" => 590, "OE2" => 600, "NE2" => 610, "CE2" => 630, "CE3" => 650,
+    "HCE" => 520, "HNE" => 540, "HNE1" => 560, "HCE1" => 580, "HOE1" => 591, "HNE2" => 620, "HCE2" => 640, "HCE3" => 660,
+    "CZ" => 810, "NZ" => 830, "CZ2" => 850, "CZ3" => 870, "OH" => 880,
+    "HCZ" => 820, "HNZ" => 840, "HCZ2" => 860, "HCZ3" => 880, "HOH" => 890,
+    "CH2" => 910, "NH1" => 950, "NH2" => 970,
+    "HCH2" => 920, "HNH1" => 960, "HH11" => 961, "HH12" => 962, "HNH2" => 980, "HH21" => 981, "HH22" => 982,
+    "C" => 5000, "HC" => 5001,
+    "O" => 6000, "OX" => 6001, "OXT" => 6002, "HOXT" => 6003,
 };
 
 pub fn is_backbone_atom(atom_name: &str) -> bool {
     BACKBONE_ATOM_NAMES.contains(atom_name.trim())
 }
 
-pub fn is_sidechain_atom(atom_name: &str) -> bool {
-    !is_backbone_atom(atom_name)
-}
-
 pub fn is_heavy_atom(atom_name: &str) -> bool {
-    !atom_name.trim().starts_with('H')
-}
-
-pub fn is_standard_amino_acid(residue_name: &str) -> bool {
-    STANDARD_AMINO_ACID_NAMES.contains(residue_name.trim())
-}
-
-pub fn three_to_one_letter_code(three_letter: &str) -> Option<char> {
-    THREE_TO_ONE_CODE.get(three_letter.trim()).copied()
-}
-
-pub fn one_to_three_letter_code(one_letter: char) -> Option<&'static str> {
-    ONE_TO_THREE_CODE.get(&one_letter).copied()
+    let first_char = atom_name.trim().chars().next();
+    !matches!(first_char, Some('H') | Some('D'))
 }
 
 pub fn residue_atom_order(atom1_name: &str, atom2_name: &str) -> Ordering {
@@ -95,33 +44,4 @@ pub fn residue_atom_order(atom1_name: &str, atom2_name: &str) -> Ordering {
         .get(atom2_name.trim())
         .unwrap_or(&i32::MAX);
     weight1.cmp(weight2)
-}
-
-#[derive(Debug, Error, PartialEq, Eq)]
-pub enum ParseMutationInfoError {
-    #[error("Invalid format for mutation info string: '{0}'")]
-    InvalidFormat(String),
-    #[error("Residue ID part is not a valid number in string: '{0}'")]
-    InvalidResidueId(String),
-}
-
-pub fn parse_mutation_info(s: &str) -> Result<(char, isize, char), ParseMutationInfoError> {
-    let trimmed = s.trim();
-    if trimmed.len() < 4 || !trimmed.contains('_') {
-        return Err(ParseMutationInfoError::InvalidFormat(s.to_string()));
-    }
-
-    let aa = trimmed.chars().next().unwrap();
-    let chain_id = trimmed.chars().last().unwrap();
-
-    let parts: Vec<_> = trimmed[1..trimmed.len() - 1].split('_').collect();
-    if parts.len() != 2 || !parts[1].is_empty() {
-        return Err(ParseMutationInfoError::InvalidFormat(s.to_string()));
-    }
-
-    let res_id: isize = parts[0]
-        .parse()
-        .map_err(|_| ParseMutationInfoError::InvalidResidueId(parts[0].to_string()))?;
-
-    Ok((aa, res_id, chain_id))
 }

--- a/crates/scream-core/src/core/utils/mod.rs
+++ b/crates/scream-core/src/core/utils/mod.rs
@@ -1,0 +1,1 @@
+pub mod geometry;

--- a/crates/scream-core/src/core/utils/mod.rs
+++ b/crates/scream-core/src/core/utils/mod.rs
@@ -1,1 +1,2 @@
 pub mod geometry;
+pub mod identifiers;


### PR DESCRIPTION
### Summary:

Introduces a foundational `utils` module containing essential tools for geometric calculations and standardized atom/residue identification. It includes a `geometry` submodule with functions for structural analysis and manipulation (e.g., dihedral angles, RMSD) and an `identifiers` submodule for fast, standardized atom classification and sorting using perfect hash functions. Additionally, enhances the core data model by introducing a strongly-typed `ResidueType` enum, providing a more robust and semantic understanding of standard amino acids.

### Changes:

- **Added Geometry Utilities (`utils::geometry`):**
  - Implemented functions for core geometric calculations using `nalgebra`:
    - `dihedral_angle`: Calculates the dihedral angle between four points.
    - `calculate_cb_position`: Computes the C-beta atom position based on backbone geometry.
    - `calculate_hn_position`: Determines the position of the amide proton.
    - `generate_sp3_hydrogens`: Generates hydrogen atoms for sp3-hybridized centers.
  - Provided structural analysis metrics:
    - `calculate_rmsd`: Calculates the Root Mean Square Deviation between two sets of coordinates.
    - `calculate_named_rmsd`: A variant of RMSD that operates on named atoms in `HashMap`.
    - `find_max_atom_deviation`: Finds the atom with the largest positional difference.
  - Included a comprehensive suite of unit tests for all geometry functions.

- **Implemented Identifier Utilities (`utils::identifiers`):**
  - Used the `phf` crate to create high-performance, compile-time static maps and sets for atom name lookups.
  - `is_backbone_atom`: A function to quickly check if an atom is part of the protein backbone.
  - `is_heavy_atom`: A utility to distinguish heavy atoms from hydrogens.
  - `residue_atom_order`: Provides a canonical sorting order for atoms within a residue, crucial for standardized file formats and analysis.

- **Introduced a Strong Typing System for Residues:**
  - Created a `ResidueType` enum to represent standard amino acids (e.g., Alanine, Glycine) and their variants (e.g., Histidine protonation states).
  - Implemented `FromStr` for parsing three-letter codes into `ResidueType`.
  - Updated the `Residue` struct to include an `Option<ResidueType>`, adding rich semantic information.
  - Modified the `MolecularSystem` and `BgfFile` parser to handle and store this new `ResidueType`.

- **Added Dependencies and Scaffolding:**
  - Added `phf` as a new dependency for identifier utilities.