### PR TITLE
fix(core): Correctly Parameterize System-Extracted Rotamers

### DIFF
--- a/crates/scream-core/src/core/rotamers/library.rs
+++ b/crates/scream-core/src/core/rotamers/library.rs
@@ -583,7 +583,7 @@ bonds = [[1, 99]]"#;
             let ala_id = system
                 .add_residue(chain_id, 1, "ALA", Some(ResidueType::Alanine))
                 .unwrap();
-            for name in &["N", "CA", "C", "CB"] {
+            for name in &["N", "CA", "C", "CB", "HB1", "HB2", "HB3"] {
                 system
                     .add_atom_to_residue(ala_id, Atom::new(name, ala_id, Default::default()))
                     .unwrap();

--- a/crates/scream-core/src/core/rotamers/library.rs
+++ b/crates/scream-core/src/core/rotamers/library.rs
@@ -271,6 +271,7 @@ impl RotamerLibrary {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::forcefield::parameterization::Parameterizer;
     use crate::core::forcefield::params::{DeltaParam, GlobalParams, NonBondedParams, VdwParam};
     use crate::core::{
         models::{
@@ -493,7 +494,14 @@ bonds = [[1, 99]]"#;
             }
             let active = [ala_id].iter().cloned().collect();
 
-            library.include_system_conformations(&system, &active, &setup.topology_registry);
+            let parameterizer =
+                Parameterizer::new(&setup.forcefield, &setup.topology_registry, 1.0);
+            library.include_system_conformations(
+                &system,
+                &active,
+                &setup.topology_registry,
+                &parameterizer,
+            );
 
             let rotamers = library.get_rotamers_for(ResidueType::Alanine).unwrap();
             assert_eq!(rotamers.len(), 1);
@@ -516,7 +524,14 @@ bonds = [[1, 99]]"#;
             }
             let active = [gly_id].iter().cloned().collect();
 
-            library.include_system_conformations(&system, &active, &setup.topology_registry);
+            let parameterizer =
+                Parameterizer::new(&setup.forcefield, &setup.topology_registry, 1.0);
+            library.include_system_conformations(
+                &system,
+                &active,
+                &setup.topology_registry,
+                &parameterizer,
+            );
 
             let rotamers = library.get_rotamers_for(ResidueType::Glycine).unwrap();
             assert_eq!(rotamers.len(), 1);
@@ -532,12 +547,21 @@ bonds = [[1, 99]]"#;
             let ala_id = system
                 .add_residue(chain_id, 1, "ALA", Some(ResidueType::Alanine))
                 .unwrap();
-            system
-                .add_atom_to_residue(ala_id, Atom::new("N", ala_id, Default::default()))
-                .unwrap();
+            for name in &["N", "CA", "C", "CB"] {
+                system
+                    .add_atom_to_residue(ala_id, Atom::new(name, ala_id, Default::default()))
+                    .unwrap();
+            }
             let active = [ala_id].iter().cloned().collect();
 
-            library.include_system_conformations(&system, &active, &setup.topology_registry);
+            let parameterizer =
+                Parameterizer::new(&setup.forcefield, &setup.topology_registry, 1.0);
+            library.include_system_conformations(
+                &system,
+                &active,
+                &setup.topology_registry,
+                &parameterizer,
+            );
             assert_eq!(
                 library
                     .get_rotamers_for(ResidueType::Alanine)
@@ -546,7 +570,12 @@ bonds = [[1, 99]]"#;
                 1
             );
 
-            library.include_system_conformations(&system, &active, &setup.topology_registry);
+            library.include_system_conformations(
+                &system,
+                &active,
+                &setup.topology_registry,
+                &parameterizer,
+            );
             assert_eq!(
                 library
                     .get_rotamers_for(ResidueType::Alanine)
@@ -567,7 +596,14 @@ bonds = [[1, 99]]"#;
                 .unwrap();
             let active = [pro_id].iter().cloned().collect();
 
-            library.include_system_conformations(&system, &active, &setup.topology_registry);
+            let parameterizer =
+                Parameterizer::new(&setup.forcefield, &setup.topology_registry, 1.0);
+            library.include_system_conformations(
+                &system,
+                &active,
+                &setup.topology_registry,
+                &parameterizer,
+            );
 
             assert!(library.get_rotamers_for(ResidueType::Proline).is_none());
         }


### PR DESCRIPTION
### Summary:

Fixes a critical crash that occurred when using the `include-input-conformation` option. The root cause was that rotamers extracted from the live system were not being parameterized, leaving them without essential data like atom roles and cached forcefield parameters, which led to failures in subsequent placement and scoring operations. The fix ensures these system-derived rotamers are fully parameterized, making them consistent with those loaded from the library. Additionally, the extraction logic has been made more robust.

### Changes:

- **Parameterized System-Extracted Rotamers:**
  - The `include_system_conformations` function in the `RotamerLibrary` now accepts a `Parameterizer` instance.
  - It now explicitly runs the full parameterization process on each newly extracted rotamer, assigning correct atom roles, VDW parameters, delta values, and H-bond types.

- **Improved Rotamer Extraction Logic:**
  - The `extract_rotamer_from_system` function was refactored for greater robustness.
  - It now correctly handles residues where atoms may serve multiple topological roles (e.g., as both an anchor and a sidechain atom in Glycine).
  - The extraction process now safely skips conformations that are missing mandatory anchor or sidechain atoms as defined in the topology, preventing panics with incomplete structures.