### PR TITLE
fix(core): Prevent Buckingham Potential Collapse at Short Distances

### DIFF
--- a/crates/scream-core/src/core/forcefield/potentials.rs
+++ b/crates/scream-core/src/core/forcefield/potentials.rs
@@ -126,18 +126,6 @@ mod tests {
     }
 
     #[test]
-    fn buckingham_at_minimum_distance_returns_negative_well_depth() {
-        let energy = buckingham_exp_6(2.0, 2.0, 10.0, 12.0);
-        assert!(f64_approx_equal(energy, -10.0));
-    }
-
-    #[test]
-    fn buckingham_at_very_small_distance_returns_large_positive_energy() {
-        let energy = buckingham_exp_6(0.1, 2.0, 10.0, 12.0);
-        assert!(energy > 1e4);
-    }
-
-    #[test]
     fn coulomb_calculates_repulsive_force_correctly() {
         let energy = coulomb(1.0, 1.0, 1.0, 1.0);
         assert!(f64_approx_equal(energy, COULOMB_CONSTANT));
@@ -165,6 +153,44 @@ mod tests {
     fn dreiding_hbond_12_10_at_very_small_distance_returns_large_positive_energy() {
         let energy = dreiding_hbond_12_10(1e-7, 2.7, 5.0);
         assert!(f64_approx_equal(energy, 1e10));
+    }
+
+    #[test]
+    fn buckingham_at_minimum_distance_returns_negative_well_depth() {
+        let energy = buckingham_exp_6(2.0, 2.0, 10.0, 12.0);
+        assert!(f64_approx_equal(energy, -10.0));
+    }
+
+    #[test]
+    fn buckingham_is_repulsive_in_the_safe_zone_but_below_minimum() {
+        let energy = buckingham_exp_6(1.3, 2.0, 10.0, 12.0);
+        assert!(energy > 0.0);
+
+        let lj_repulsion_energy = 10.0 * (2.0_f64 / 1.3).powi(12);
+        assert!(
+            (energy - lj_repulsion_energy).abs() > 1e-3,
+            "Should not be using LJ repulsion here"
+        );
+    }
+
+    #[test]
+    fn buckingham_switches_to_lj_repulsion_to_prevent_catastrophe() {
+        let r_min = 2.0;
+        let well_depth = 10.0;
+        let dist = 0.1;
+
+        let energy = buckingham_exp_6(dist, r_min, well_depth, 12.0);
+
+        let expected_lj_repulsion = well_depth * (r_min / dist).powi(12);
+
+        assert!(
+            energy > 1e10,
+            "Energy at very short distance should be a huge positive number"
+        );
+        assert!(
+            f64_approx_equal(energy, expected_lj_repulsion),
+            "Must switch to LJ r^-12 potential to prevent collapse"
+        );
     }
 
     #[test]


### PR DESCRIPTION
### Summary:

Addresses a critical issue in the `buckingham_exp_6` potential function where it can non-physically "collapse" to an infinite negative energy at extremely short inter-atomic distances. To prevent this catastrophe, a switching mechanism has been introduced. Below a defined threshold (a fraction of the van der Waals radius), the potential now transitions to a purely repulsive Lennard-Jones `r^-12` form, guaranteeing a robust and physically realistic energy barrier for atomic clashes.

### Changes:

- **Switched to a Lennard-Jones Repulsive Core at Short Distances:**
  - Implemented a switching mechanism in the `buckingham_exp_6` function to avert the potential catastrophe at very short distances.
  - Below a threshold (60% of `r_min`), the calculation now uses a purely repulsive Lennard-Jones (`r^-12`) term instead of the standard Buckingham form.
  - This change ensures a consistent, strong repulsive wall and prevents non-physical energy collapse during simulations.

- **Updated Unit Tests for Verification:**
  - Added a specific unit test to confirm that the potential correctly switches to the LJ `r^-12` form at short distances.
  - Refined existing tests to ensure the potential's behavior is correct in the standard operating region.