### PR TITLE
feat(core): Implement Configurable, Role-Based Energy Weighting System

### DIFF
--- a/crates/scream-cli/src/config.rs
+++ b/crates/scream-cli/src/config.rs
@@ -2,6 +2,8 @@ use crate::cli::{IncludeInputConformation, PlaceArgs};
 use crate::data::DataManager;
 use crate::error::{CliError, Result};
 use crate::utils::parser;
+use screampp::core::forcefield::params as ff_params;
+use screampp::core::models::atom::AtomRole;
 use screampp::engine::config as core_config;
 use serde::Deserialize;
 use std::path::{Path, PathBuf};
@@ -73,6 +75,65 @@ struct PartialForcefieldConfig {
     delta_params_path: Option<String>,
     #[serde(rename = "s-factor")]
     s_factor: Option<f64>,
+    #[serde(default, rename = "energy-weights")]
+    energy_weights: EnergyWeights,
+}
+
+#[derive(Deserialize, Debug, Clone, Copy)]
+#[serde(deny_unknown_fields)]
+pub struct EnergyComponentWeights {
+    #[serde(default = "default_one")]
+    pub vdw: f64,
+    #[serde(default = "default_one")]
+    pub coulomb: f64,
+    #[serde(default = "default_one")]
+    pub hbond: f64,
+}
+
+fn default_one() -> f64 {
+    1.0
+}
+
+#[derive(Deserialize, Debug, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct WeightRule {
+    pub groups: [String; 2],
+    pub weights: EnergyComponentWeights,
+}
+
+#[derive(Deserialize, Debug, Clone, Default)]
+#[serde(deny_unknown_fields)]
+pub struct EnergyWeights {
+    #[serde(default)]
+    pub rules: Vec<WeightRule>,
+}
+
+impl From<EnergyComponentWeights> for ff_params::EnergyComponentWeights {
+    fn from(w: EnergyComponentWeights) -> Self {
+        Self {
+            vdw: w.vdw,
+            coulomb: w.coulomb,
+            hbond: w.hbond,
+        }
+    }
+}
+impl From<EnergyWeights> for ff_params::EnergyWeights {
+    fn from(w: EnergyWeights) -> Self {
+        use std::str::FromStr;
+        let mut rules: Vec<ff_params::WeightRule> = Vec::new();
+        for r in w.rules.into_iter() {
+            if let (Ok(g1), Ok(g2)) = (
+                AtomRole::from_str(&r.groups[0]),
+                AtomRole::from_str(&r.groups[1]),
+            ) {
+                rules.push(ff_params::WeightRule {
+                    groups: [g1, g2],
+                    weights: r.weights.into(),
+                });
+            }
+        }
+        ff_params::EnergyWeights { rules }
+    }
 }
 
 #[derive(Deserialize, Debug, Default)]
@@ -222,6 +283,7 @@ impl PartialPlacementConfig {
             .forcefield_path(forcefield_path)
             .delta_params_path(delta_params_path)
             .s_factor(s_factor)
+            .energy_weights(ff_config.energy_weights.into())
             .rotamer_library_path(rotamer_library_path)
             .topology_registry_path(topology_registry_path)
             .max_iterations(

--- a/crates/scream-core/src/core/forcefield/parameterization.rs
+++ b/crates/scream-core/src/core/forcefield/parameterization.rs
@@ -371,11 +371,11 @@ impl From<super::params::VdwParam> for CachedVdwParam {
 mod tests {
     use super::*;
     use crate::core::{
+        forcefield::params::EnergyWeights,
         models::{chain::ChainType, residue::ResidueType, system::MolecularSystem},
         rotamers::rotamer::Rotamer,
         topology::registry::TopologyRegistry,
     };
-    use crate::engine::config::EnergyWeights;
     use nalgebra::Point3;
     use std::{fs::File, io::Write};
     use tempfile::{TempDir, tempdir};

--- a/crates/scream-core/src/core/forcefield/parameterization.rs
+++ b/crates/scream-core/src/core/forcefield/parameterization.rs
@@ -375,6 +375,7 @@ mod tests {
         rotamers::rotamer::Rotamer,
         topology::registry::TopologyRegistry,
     };
+    use crate::engine::config::EnergyWeights;
     use nalgebra::Point3;
     use std::{fs::File, io::Write};
     use tempfile::{TempDir, tempdir};
@@ -423,7 +424,8 @@ mod tests {
         )
         .unwrap();
 
-        let forcefield = Forcefield::load(&ff_path, &delta_path, &[]).unwrap();
+        let forcefield =
+            Forcefield::load(&ff_path, &delta_path, &EnergyWeights::default()).unwrap();
 
         let topo_path = dir.join("topo.toml");
         let mut topo_file = File::create(&topo_path).unwrap();

--- a/crates/scream-core/src/core/forcefield/parameterization.rs
+++ b/crates/scream-core/src/core/forcefield/parameterization.rs
@@ -423,7 +423,7 @@ mod tests {
         )
         .unwrap();
 
-        let forcefield = Forcefield::load(&ff_path, &delta_path).unwrap();
+        let forcefield = Forcefield::load(&ff_path, &delta_path, &[]).unwrap();
 
         let topo_path = dir.join("topo.toml");
         let mut topo_file = File::create(&topo_path).unwrap();

--- a/crates/scream-core/src/core/forcefield/params.rs
+++ b/crates/scream-core/src/core/forcefield/params.rs
@@ -338,7 +338,8 @@ mod tests {
         )
         .unwrap();
 
-        let ff = Forcefield::load(&non_bonded_path, &delta_path, &[]).unwrap();
+        let ff =
+            Forcefield::load(&non_bonded_path, &delta_path, &EnergyWeights::default()).unwrap();
 
         assert!(!ff.non_bonded.vdw.is_empty());
         assert!(!ff.deltas.is_empty());
@@ -354,7 +355,7 @@ mod tests {
         let result = Forcefield::load(
             &non_bonded_path,
             &delta_path, // delta.csv does not exist
-            &[],
+            &EnergyWeights::default(),
         );
         assert!(matches!(result, Err(ParamLoadError::Toml { .. })));
     }

--- a/crates/scream-core/src/core/forcefield/params.rs
+++ b/crates/scream-core/src/core/forcefield/params.rs
@@ -82,8 +82,7 @@ pub struct EnergyWeights {
 pub struct Forcefield {
     pub non_bonded: NonBondedParams,
     pub deltas: HashMap<(String, String), DeltaParam>,
-    pub energy_weights: EnergyWeights,
-    weight_map: HashMap<(AtomRole, AtomRole), EnergyComponentWeights>,
+    pub weight_map: HashMap<(AtomRole, AtomRole), EnergyComponentWeights>,
 }
 
 #[derive(Debug, Error)]
@@ -103,27 +102,6 @@ pub enum ParamLoadError {
 }
 
 impl Forcefield {
-    #[cfg(test)]
-    pub fn from_parts(
-        non_bonded: NonBondedParams,
-        deltas: HashMap<(String, String), DeltaParam>,
-        energy_weights: EnergyWeights,
-    ) -> Self {
-        let mut weight_map: HashMap<(AtomRole, AtomRole), EnergyComponentWeights> = HashMap::new();
-        for rule in &energy_weights.rules {
-            let a = rule.groups[0];
-            let b = rule.groups[1];
-            let key = if a <= b { (a, b) } else { (b, a) };
-            weight_map.insert(key, rule.weights);
-        }
-        Self {
-            non_bonded,
-            deltas,
-            energy_weights,
-            weight_map,
-        }
-    }
-
     pub fn load(
         non_bonded_path: &Path,
         delta_path: &Path,
@@ -143,14 +121,8 @@ impl Forcefield {
         Ok(Self {
             non_bonded,
             deltas,
-            energy_weights: energy_weights_config.clone(),
             weight_map,
         })
-    }
-
-    pub fn weights_for_roles(&self, r1: AtomRole, r2: AtomRole) -> EnergyComponentWeights {
-        let key = if r1 <= r2 { (r1, r2) } else { (r2, r1) };
-        self.weight_map.get(&key).copied().unwrap_or_default()
     }
 
     fn load_non_bonded(path: &Path) -> Result<NonBondedParams, ParamLoadError> {

--- a/crates/scream-core/src/core/forcefield/params.rs
+++ b/crates/scream-core/src/core/forcefield/params.rs
@@ -317,7 +317,7 @@ mod tests {
         )
         .unwrap();
 
-        let ff = Forcefield::load(&non_bonded_path, &delta_path).unwrap();
+        let ff = Forcefield::load(&non_bonded_path, &delta_path, &[]).unwrap();
 
         assert!(!ff.non_bonded.vdw.is_empty());
         assert!(!ff.deltas.is_empty());
@@ -333,6 +333,7 @@ mod tests {
         let result = Forcefield::load(
             &non_bonded_path,
             &delta_path, // delta.csv does not exist
+            &[],
         );
         assert!(matches!(result, Err(ParamLoadError::Toml { .. })));
     }

--- a/crates/scream-core/src/core/forcefield/scoring.rs
+++ b/crates/scream-core/src/core/forcefield/scoring.rs
@@ -86,13 +86,21 @@ impl<'a> Scorer<'a> {
                     .system
                     .atom(id2)
                     .ok_or(ScoringError::AtomNotFound(id2))?;
+                let (r1, r2) = (atom1.role, atom2.role);
+                let key = if r1 <= r2 { (r1, r2) } else { (r2, r1) };
+                let weights = self
+                    .forcefield
+                    .weight_map
+                    .get(&key)
+                    .copied()
+                    .unwrap_or_default();
 
-                energy.vdw += EnergyCalculator::calculate_vdw(atom1, atom2)?;
+                energy.vdw += EnergyCalculator::calculate_vdw(atom1, atom2)? * weights.vdw;
                 energy.coulomb += EnergyCalculator::calculate_coulomb(
                     atom1,
                     atom2,
                     self.forcefield.non_bonded.globals.dielectric_constant,
-                );
+                ) * weights.coulomb;
             }
         }
         Ok(energy)

--- a/crates/scream-core/src/core/forcefield/scoring.rs
+++ b/crates/scream-core/src/core/forcefield/scoring.rs
@@ -431,6 +431,7 @@ mod tests {
                     hbond_acceptors: HashSet::new(),
                 },
                 deltas: HashMap::new(),
+                weight_map: HashMap::new(),
             }
         }
     }

--- a/crates/scream-core/src/core/forcefield/scoring.rs
+++ b/crates/scream-core/src/core/forcefield/scoring.rs
@@ -174,8 +174,16 @@ impl<'a> Scorer<'a> {
                                 hbond_param.equilibrium_distance,
                                 hbond_param.well_depth,
                             );
+                            let (r1, r2) = (donor.role, acceptor.role);
+                            let key = if r1 <= r2 { (r1, r2) } else { (r2, r1) };
+                            let weights = self
+                                .forcefield
+                                .weight_map
+                                .get(&key)
+                                .copied()
+                                .unwrap_or_default();
 
-                            hbond_energy += energy_contribution;
+                            hbond_energy += energy_contribution * weights.hbond;
                         }
                     }
                 }

--- a/crates/scream-core/src/core/models/atom.rs
+++ b/crates/scream-core/src/core/models/atom.rs
@@ -122,4 +122,33 @@ mod tests {
         assert_eq!(role, role_clone);
         assert_eq!(format!("{:?}", role), "Sidechain");
     }
+
+    #[test]
+    fn from_str_parses_valid_roles() {
+        assert_eq!(AtomRole::from_str("backbone"), Ok(AtomRole::Backbone));
+        assert_eq!(AtomRole::from_str("sidechain"), Ok(AtomRole::Sidechain));
+        assert_eq!(AtomRole::from_str("side-chain"), Ok(AtomRole::Sidechain));
+        assert_eq!(AtomRole::from_str("side_chain"), Ok(AtomRole::Sidechain));
+        assert_eq!(AtomRole::from_str("ligand"), Ok(AtomRole::Ligand));
+        assert_eq!(AtomRole::from_str("water"), Ok(AtomRole::Water));
+        assert_eq!(AtomRole::from_str("other"), Ok(AtomRole::Other));
+        assert_eq!(AtomRole::from_str("unknown"), Ok(AtomRole::Other));
+    }
+
+    #[test]
+    fn from_str_is_case_insensitive() {
+        assert_eq!(AtomRole::from_str("BACKBONE"), Ok(AtomRole::Backbone));
+        assert_eq!(AtomRole::from_str("SideChain"), Ok(AtomRole::Sidechain));
+        assert_eq!(AtomRole::from_str("LiGaNd"), Ok(AtomRole::Ligand));
+        assert_eq!(AtomRole::from_str("wAtEr"), Ok(AtomRole::Water));
+        assert_eq!(AtomRole::from_str("OtHeR"), Ok(AtomRole::Other));
+    }
+
+    #[test]
+    fn from_str_returns_err_for_invalid_role() {
+        assert_eq!(AtomRole::from_str("foo"), Err(()));
+        assert_eq!(AtomRole::from_str("").unwrap_err(), ());
+        assert_eq!(AtomRole::from_str("123"), Err(()));
+        assert_eq!(AtomRole::from_str("side chainz"), Err(()));
+    }
 }

--- a/crates/scream-core/src/core/models/atom.rs
+++ b/crates/scream-core/src/core/models/atom.rs
@@ -1,7 +1,8 @@
 use super::ids::ResidueId;
 use nalgebra::Point3;
+use std::str::FromStr;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Default)]
 pub enum AtomRole {
     Backbone,  // Backbone atom (e.g., C, N, O)
     Sidechain, // Sidechain atom (e.g., CH3, OH)
@@ -57,6 +58,21 @@ impl Atom {
             delta: 0.0,
             vdw_param: CachedVdwParam::None,
             hbond_type_id: -1,
+        }
+    }
+}
+
+impl FromStr for AtomRole {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_ascii_lowercase().as_str() {
+            "backbone" => Ok(AtomRole::Backbone),
+            "sidechain" | "side-chain" | "side_chain" => Ok(AtomRole::Sidechain),
+            "ligand" => Ok(AtomRole::Ligand),
+            "water" => Ok(AtomRole::Water),
+            "other" | "unknown" => Ok(AtomRole::Other),
+            _ => Err(()),
         }
     }
 }

--- a/crates/scream-core/src/core/rotamers/library.rs
+++ b/crates/scream-core/src/core/rotamers/library.rs
@@ -308,7 +308,9 @@ impl RotamerLibrary {
 mod tests {
     use super::*;
     use crate::core::forcefield::parameterization::Parameterizer;
-    use crate::core::forcefield::params::{DeltaParam, GlobalParams, NonBondedParams, VdwParam};
+    use crate::core::forcefield::params::{
+        DeltaParam, EnergyWeights, GlobalParams, NonBondedParams, VdwParam,
+    };
     use crate::core::{
         models::{
             atom::{Atom, AtomRole},
@@ -355,19 +357,17 @@ mod tests {
                 well_depth: 0.12,
             },
         );
-        let forcefield = Forcefield {
-            deltas,
-            non_bonded: NonBondedParams {
-                globals: GlobalParams {
-                    dielectric_constant: 1.0,
-                    potential_function: "".to_string(),
-                },
-                vdw,
-                hbond: HashMap::new(),
-                hbond_donors: HashSet::new(),
-                hbond_acceptors: HashSet::new(),
+        let non_bonded = NonBondedParams {
+            globals: GlobalParams {
+                dielectric_constant: 1.0,
+                potential_function: "".to_string(),
             },
+            vdw,
+            hbond: HashMap::new(),
+            hbond_donors: HashSet::new(),
+            hbond_acceptors: HashSet::new(),
         };
+        let forcefield = Forcefield::from_parts(non_bonded, deltas, EnergyWeights::default());
 
         let topology_toml_path = temp_dir.path().join("topology.toml");
         let mut topology_file = File::create(&topology_toml_path).unwrap();

--- a/crates/scream-core/src/core/rotamers/library.rs
+++ b/crates/scream-core/src/core/rotamers/library.rs
@@ -308,9 +308,7 @@ impl RotamerLibrary {
 mod tests {
     use super::*;
     use crate::core::forcefield::parameterization::Parameterizer;
-    use crate::core::forcefield::params::{
-        DeltaParam, EnergyWeights, GlobalParams, NonBondedParams, VdwParam,
-    };
+    use crate::core::forcefield::params::{DeltaParam, GlobalParams, NonBondedParams, VdwParam};
     use crate::core::{
         models::{
             atom::{Atom, AtomRole},
@@ -357,17 +355,20 @@ mod tests {
                 well_depth: 0.12,
             },
         );
-        let non_bonded = NonBondedParams {
-            globals: GlobalParams {
-                dielectric_constant: 1.0,
-                potential_function: "".to_string(),
+        let forcefield = Forcefield {
+            deltas,
+            non_bonded: NonBondedParams {
+                globals: GlobalParams {
+                    dielectric_constant: 1.0,
+                    potential_function: "".to_string(),
+                },
+                vdw,
+                hbond: HashMap::new(),
+                hbond_donors: HashSet::new(),
+                hbond_acceptors: HashSet::new(),
             },
-            vdw,
-            hbond: HashMap::new(),
-            hbond_donors: HashSet::new(),
-            hbond_acceptors: HashSet::new(),
+            weight_map: HashMap::new(),
         };
-        let forcefield = Forcefield::from_parts(non_bonded, deltas, EnergyWeights::default());
 
         let topology_toml_path = temp_dir.path().join("topology.toml");
         let mut topology_file = File::create(&topology_toml_path).unwrap();

--- a/crates/scream-core/src/engine/config.rs
+++ b/crates/scream-core/src/engine/config.rs
@@ -1,4 +1,4 @@
-use crate::core::models::atom::AtomRole;
+use crate::core::forcefield::params::EnergyWeights;
 use crate::core::models::residue::ResidueType;
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -41,34 +41,6 @@ pub struct SimulatedAnnealingConfig {
     pub final_temperature: f64,
     pub cooling_rate: f64,
     pub steps_per_temperature: usize,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub struct EnergyComponentWeights {
-    pub vdw: f64,
-    pub coulomb: f64,
-    pub hbond: f64,
-}
-
-impl Default for EnergyComponentWeights {
-    fn default() -> Self {
-        Self {
-            vdw: 1.0,
-            coulomb: 1.0,
-            hbond: 1.0,
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub struct WeightRule {
-    pub groups: [AtomRole; 2],
-    pub weights: EnergyComponentWeights,
-}
-
-#[derive(Debug, Clone, PartialEq, Default)]
-pub struct EnergyWeights {
-    pub rules: Vec<WeightRule>,
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/scream-core/src/engine/config.rs
+++ b/crates/scream-core/src/engine/config.rs
@@ -1,3 +1,4 @@
+use crate::core::models::atom::AtomRole;
 use crate::core::models::residue::ResidueType;
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -42,11 +43,40 @@ pub struct SimulatedAnnealingConfig {
     pub steps_per_temperature: usize,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct EnergyComponentWeights {
+    pub vdw: f64,
+    pub coulomb: f64,
+    pub hbond: f64,
+}
+
+impl Default for EnergyComponentWeights {
+    fn default() -> Self {
+        Self {
+            vdw: 1.0,
+            coulomb: 1.0,
+            hbond: 1.0,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct WeightRule {
+    pub groups: [AtomRole; 2],
+    pub weights: EnergyComponentWeights,
+}
+
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct EnergyWeights {
+    pub rules: Vec<WeightRule>,
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct ForcefieldConfig {
     pub forcefield_path: PathBuf,
     pub delta_params_path: PathBuf,
     pub s_factor: f64,
+    pub energy_weights: EnergyWeights,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -128,6 +158,7 @@ pub struct PlacementConfigBuilder {
     forcefield_path: Option<PathBuf>,
     delta_params_path: Option<PathBuf>,
     s_factor: Option<f64>,
+    energy_weights: Option<EnergyWeights>,
     rotamer_library_path: Option<PathBuf>,
     topology_registry_path: Option<PathBuf>,
     max_iterations: Option<usize>,
@@ -154,6 +185,10 @@ impl PlacementConfigBuilder {
     }
     pub fn s_factor(mut self, factor: f64) -> Self {
         self.s_factor = Some(factor);
+        self
+    }
+    pub fn energy_weights(mut self, weights: EnergyWeights) -> Self {
+        self.energy_weights = Some(weights);
         self
     }
     pub fn rotamer_library_path(mut self, path: impl Into<PathBuf>) -> Self {
@@ -204,6 +239,7 @@ impl PlacementConfigBuilder {
             s_factor: self
                 .s_factor
                 .ok_or(ConfigError::MissingParameter("s_factor"))?,
+            energy_weights: self.energy_weights.unwrap_or_default(),
         };
         let sampling = SamplingConfig {
             rotamer_library_path: self
@@ -246,6 +282,7 @@ pub struct DesignConfigBuilder {
     forcefield_path: Option<PathBuf>,
     delta_params_path: Option<PathBuf>,
     s_factor: Option<f64>,
+    energy_weights: Option<EnergyWeights>,
     rotamer_library_path: Option<PathBuf>,
     topology_registry_path: Option<PathBuf>,
     max_iterations: Option<usize>,
@@ -273,6 +310,10 @@ impl DesignConfigBuilder {
     }
     pub fn s_factor(mut self, factor: f64) -> Self {
         self.s_factor = Some(factor);
+        self
+    }
+    pub fn energy_weights(mut self, weights: EnergyWeights) -> Self {
+        self.energy_weights = Some(weights);
         self
     }
 
@@ -330,6 +371,7 @@ impl DesignConfigBuilder {
             s_factor: self
                 .s_factor
                 .ok_or(ConfigError::MissingParameter("s_factor"))?,
+            energy_weights: self.energy_weights.unwrap_or_default(),
         };
         let sampling = SamplingConfig {
             rotamer_library_path: self
@@ -377,6 +419,7 @@ pub struct AnalyzeConfigBuilder {
     forcefield_path: Option<PathBuf>,
     delta_params_path: Option<PathBuf>,
     s_factor: Option<f64>,
+    energy_weights: Option<EnergyWeights>,
     topology_registry_path: Option<PathBuf>,
     analysis_type: Option<AnalysisType>,
 }
@@ -396,6 +439,10 @@ impl AnalyzeConfigBuilder {
     }
     pub fn s_factor(mut self, factor: f64) -> Self {
         self.s_factor = Some(factor);
+        self
+    }
+    pub fn energy_weights(mut self, weights: EnergyWeights) -> Self {
+        self.energy_weights = Some(weights);
         self
     }
     pub fn topology_registry_path(mut self, path: impl Into<PathBuf>) -> Self {
@@ -418,6 +465,7 @@ impl AnalyzeConfigBuilder {
             s_factor: self
                 .s_factor
                 .ok_or(ConfigError::MissingParameter("s_factor"))?,
+            energy_weights: self.energy_weights.unwrap_or_default(),
         };
 
         Ok(AnalyzeConfig {

--- a/crates/scream-core/src/engine/context.rs
+++ b/crates/scream-core/src/engine/context.rs
@@ -620,6 +620,7 @@ mod tests {
                     hbond_acceptors: HashSet::new(),
                 },
                 deltas: HashMap::new(),
+                weight_map: HashMap::new(),
             };
 
             let context = OptimizationContext::new(

--- a/crates/scream-core/src/engine/tasks/clash_detection.rs
+++ b/crates/scream-core/src/engine/tasks/clash_detection.rs
@@ -129,6 +129,7 @@ mod tests {
         Forcefield {
             non_bonded,
             deltas: HashMap::new(),
+            weight_map: HashMap::new(),
         }
     }
 

--- a/crates/scream-core/src/engine/tasks/doublet_optimization.rs
+++ b/crates/scream-core/src/engine/tasks/doublet_optimization.rs
@@ -316,6 +316,7 @@ sidechain_atoms = ["CB"]
                 hbond_acceptors: HashSet::new(),
             },
             deltas: HashMap::new(),
+            weight_map: HashMap::new(),
         };
 
         let topology_registry = TopologyRegistry::load(&topology_path).unwrap();
@@ -457,6 +458,7 @@ sidechain_atoms = ["CB"]
                 hbond_acceptors: HashSet::new(),
             },
             deltas: HashMap::new(),
+            weight_map: HashMap::new(),
         };
 
         let topology_registry = TopologyRegistry::load(&topology_path).unwrap();

--- a/crates/scream-core/src/engine/tasks/el_energy.rs
+++ b/crates/scream-core/src/engine/tasks/el_energy.rs
@@ -283,7 +283,7 @@ where
 mod tests {
     use super::*;
     use crate::core::{
-        forcefield::params::Forcefield,
+        forcefield::params::{EnergyWeights, Forcefield},
         models::{atom::Atom, chain::ChainType, residue::ResidueType, system::MolecularSystem},
         rotamers::{library::RotamerLibrary, rotamer::Rotamer},
         topology::registry::TopologyRegistry,
@@ -385,7 +385,7 @@ mod tests {
             .unwrap();
             let delta_path = dir.path().join("delta.csv");
             std::fs::write(&delta_path, "residue_type,atom_name,mu,sigma\n").unwrap();
-            Forcefield::load(&ff_path, &delta_path, &[]).unwrap()
+            Forcefield::load(&ff_path, &delta_path, &EnergyWeights::default()).unwrap()
         }
 
         fn create_topology_registry(dir: &tempfile::TempDir) -> TopologyRegistry {

--- a/crates/scream-core/src/engine/tasks/el_energy.rs
+++ b/crates/scream-core/src/engine/tasks/el_energy.rs
@@ -385,7 +385,7 @@ mod tests {
             .unwrap();
             let delta_path = dir.path().join("delta.csv");
             std::fs::write(&delta_path, "residue_type,atom_name,mu,sigma\n").unwrap();
-            Forcefield::load(&ff_path, &delta_path).unwrap()
+            Forcefield::load(&ff_path, &delta_path, &[]).unwrap()
         }
 
         fn create_topology_registry(dir: &tempfile::TempDir) -> TopologyRegistry {

--- a/crates/scream-core/src/engine/tasks/fixed_energy.rs
+++ b/crates/scream-core/src/engine/tasks/fixed_energy.rs
@@ -194,7 +194,7 @@ mod tests {
     fn setup() -> TestSetup {
         let tmp = tempfile::tempdir().unwrap();
         let (ff_path, delta_path, topo_path) = write_test_files(&tmp);
-        let forcefield = Forcefield::load(&ff_path, &delta_path).unwrap();
+        let forcefield = Forcefield::load(&ff_path, &delta_path, &[]).unwrap();
         let topology_registry = TopologyRegistry::load(&topo_path).unwrap();
 
         let mut system = MolecularSystem::new();

--- a/crates/scream-core/src/engine/tasks/fixed_energy.rs
+++ b/crates/scream-core/src/engine/tasks/fixed_energy.rs
@@ -62,7 +62,7 @@ where
 mod tests {
     use super::*;
     use crate::core::forcefield::parameterization::Parameterizer;
-    use crate::core::forcefield::params::Forcefield;
+    use crate::core::forcefield::params::{EnergyWeights, Forcefield};
     use crate::core::forcefield::scoring::Scorer;
     use crate::core::models::atom::Atom;
     use crate::core::models::chain::ChainType;
@@ -194,7 +194,8 @@ mod tests {
     fn setup() -> TestSetup {
         let tmp = tempfile::tempdir().unwrap();
         let (ff_path, delta_path, topo_path) = write_test_files(&tmp);
-        let forcefield = Forcefield::load(&ff_path, &delta_path, &[]).unwrap();
+        let forcefield =
+            Forcefield::load(&ff_path, &delta_path, &EnergyWeights::default()).unwrap();
         let topology_registry = TopologyRegistry::load(&topo_path).unwrap();
 
         let mut system = MolecularSystem::new();

--- a/crates/scream-core/src/engine/tasks/interaction_energy.rs
+++ b/crates/scream-core/src/engine/tasks/interaction_energy.rs
@@ -128,7 +128,7 @@ fn collect_active_sidechain_atoms(
 mod tests {
     use super::*;
     use crate::core::{
-        forcefield::parameterization::Parameterizer,
+        forcefield::{parameterization::Parameterizer, params::EnergyWeights},
         models::{
             atom::{Atom, AtomRole},
             chain::ChainType,
@@ -250,7 +250,7 @@ mod tests {
         let delta_path = temp_dir.path().join("test.delta.csv");
         File::create(&delta_path).unwrap();
 
-        Forcefield::load(&ff_path, &delta_path, &[]).unwrap()
+        Forcefield::load(&ff_path, &delta_path, &EnergyWeights::default()).unwrap()
     }
 
     fn create_test_topology_registry(temp_dir: &TempDir) -> TopologyRegistry {

--- a/crates/scream-core/src/engine/tasks/interaction_energy.rs
+++ b/crates/scream-core/src/engine/tasks/interaction_energy.rs
@@ -250,7 +250,7 @@ mod tests {
         let delta_path = temp_dir.path().join("test.delta.csv");
         File::create(&delta_path).unwrap();
 
-        Forcefield::load(&ff_path, &delta_path).unwrap()
+        Forcefield::load(&ff_path, &delta_path, &[]).unwrap()
     }
 
     fn create_test_topology_registry(temp_dir: &TempDir) -> TopologyRegistry {

--- a/crates/scream-core/src/workflows/place.rs
+++ b/crates/scream-core/src/workflows/place.rs
@@ -41,6 +41,7 @@ pub fn run(
     let forcefield = Forcefield::load(
         &config.forcefield.forcefield_path,
         &config.forcefield.delta_params_path,
+        &config.forcefield.energy_weights,
     )?;
     let topology_registry = TopologyRegistry::load(&config.topology_registry_path)?;
     let mut rotamer_library = RotamerLibrary::load(
@@ -408,7 +409,7 @@ fn run_simulated_annealing(
 
     if total_steps > 0 {
         if performed_steps < total_steps {
-            let remaining = (total_steps - performed_steps) as u64;
+            let remaining = total_steps - performed_steps;
             if remaining > 0 {
                 context
                     .reporter


### PR DESCRIPTION
### Summary:

Introduces a flexible energy weighting system that allows for fine-grained control over interaction energies based on atom roles (e.g., `Backbone`, `Sidechain`, `Ligand`). Users can now define custom weights for VDW, Coulomb, and H-bond energy components for specific pairs of roles via the main TOML configuration file. This enhancement enables sophisticated energy models, such as up-weighting protein-ligand interactions or down-weighting intra-backbone energies, providing greater control over the optimization process. The `Scorer` and `Forcefield` modules have been updated to seamlessly integrate and apply these weights during energy calculations.

### Changes:

- **Implemented Energy Weighting System:**
  - `forcefield/params.rs`: Introduced `EnergyWeights`, `WeightRule`, and `EnergyComponentWeights` structs to define the weighting system. The `Forcefield` struct now includes a `weight_map` for fast, role-based lookup of weights.
  - `config.rs`: Added a `forcefield.energy-weights` section to the CLI configuration schema, allowing users to specify rules like `groups = ["Backbone", "Ligand"]` with custom `vdw`, `coulomb`, and `hbond` weights.
  - `forcefield/scoring.rs`: The `Scorer` now retrieves the appropriate weight for each interacting atom pair based on their `AtomRole` and applies it to the corresponding energy component.

- **Enhanced CLI and Data Handling:**
  - The CLI was updated to recognize and parse the new `energy-weights` configuration block.