### PR TITLE
fix(core): Correct BGF CONECT Record Formatting for VMD Compatibility

### DIFF
--- a/crates/scream-core/src/core/io/bgf.rs
+++ b/crates/scream-core/src/core/io/bgf.rs
@@ -529,11 +529,12 @@ ATOM       6 CA    ALA B     2   3.00000   0.00000   1.00000 C_3    1 4  0.07000
 ATOM       7 CB    ALA B     2   3.50000   1.50000   1.00000 C_3    1 4 -0.18000
 FORMAT CONECT (a6,12i6)
 CONECT     1     2
-CONECT     2     3
-CONECT     3     4
-CONECT     3     5
-CONECT     5     6
-CONECT     6     7
+CONECT     2     1     3
+CONECT     3     2     4     5
+CONECT     4     3
+CONECT     5     3     6
+CONECT     6     5     7
+CONECT     7     6
 END
 "#;
 
@@ -677,7 +678,7 @@ END
             .iter()
             .filter(|l| l.starts_with("CONECT"))
             .collect();
-        assert_eq!(conect_lines.len(), 2);
+        assert_eq!(conect_lines.len(), 4);
 
         let bond1_found = conect_lines
             .iter()


### PR DESCRIPTION
### Summary:

Corrected the BGF file writer to generate `CONECT` records that are fully compatible with strict parsers like VMD and MPSim. The previous implementation wrote only one bond pair per line, which is non-standard. The new implementation now writes a single `CONECT` record for each atom, followed by all of its bonded neighbors on the same line, adhering to the standard BGF format.

### Changes:

- Refactored the `CONECT` record generation logic in `bgf.rs`.
- Instead of creating a `CONECT` line for each bond, the writer now builds an adjacency list based on the system's topology.
- For each atom with bonds, a single `CONECT` record is now generated, listing the atom's serial followed by the serials of all its bonded neighbors.
- The output now correctly handles cases where an atom has more neighbors than can fit on a single line by creating continuation `CONECT` records.
- Updated unit tests to verify the new, standard-compliant `CONECT` format.