### PR TITLE
fix(core): Exclude Disulfide-Bonded Cysteines from Optimization

### DIFF
--- a/crates/scream-core/src/core/models/residue.rs
+++ b/crates/scream-core/src/core/models/residue.rs
@@ -128,7 +128,7 @@ impl ResidueType {
             "TRP" => Some(ResidueType::Tryptophan),
             "TYR" => Some(ResidueType::Tyrosine),
             "ASN" => Some(ResidueType::Asparagine),
-            "CYS" => Some(ResidueType::Cysteine),
+            "CYS" | "CYX" => Some(ResidueType::Cysteine),
             "GLN" => Some(ResidueType::Glutamine),
             "SER" => Some(ResidueType::Serine),
             "THR" => Some(ResidueType::Threonine),


### PR DESCRIPTION
### Summary:

Implemented a mechanism to automatically detect and exclude cysteine residues involved in disulfide bonds from the side-chain optimization process. This prevents the placement workflow from breaking existing, structurally important disulfide bridges, ensuring the generation of valid and realistic protein models. The system now correctly identifies `CYS` and `CYX` residues participating in these bonds and removes them from the set of active residues before optimization begins.

### Changes:

- **Implemented Disulfide Bond Detection:**
  - Added a `find_disulfide_bonded_residues` method to `MolecularSystem`.
  - This method efficiently identifies pairs of Cysteine residues whose Sulfur-Gamma (SG) atoms are covalently bonded.

- **Updated Residue Parsing:**
  - The `ResidueType` parser now recognizes "CYX" as an alias for Cysteine, improving compatibility with various PDB formats.

- **Integrated into Placement Workflow:**
  - The `place` workflow now calls `find_disulfide_bonded_residues` during the preparation phase.
  - Any identified disulfide-bonded cysteines are automatically removed from the set of `active_residues`, effectively freezing them during optimization.

- **Corrected Energy Grid Calculation:**
  - Modified the pairwise energy calculation in `EnergyGrid` to use a more robust iteration method, ensuring correct energy summation.